### PR TITLE
Changed default settings for Windows.

### DIFF
--- a/JSCS-Formatter.sublime-settings
+++ b/JSCS-Formatter.sublime-settings
@@ -3,13 +3,13 @@
   // https://github.com/victorporof/Sublime-HTMLPrettify#oh-noez-command-not-found
   // http://nodejs.org/#download
   "node_path": {
-    "windows": "C:/Program Files/nodejs/node.exe",
+    "windows": "node.exe",
     "linux": "/usr/bin/nodejs",
     "osx": "/usr/local/bin/node"
   },
 
   "jscs_path": {
-    "windows": "C:/Program Files/nodejs/jscs",
+    "windows": "%APPDATA%/npm/node_modules/jscs/bin/jscs",
     "linux": "/usr/bin/jscs",
     "osx": "/usr/local/bin/jscs"
   },


### PR DESCRIPTION
"global" _npm_ path is located at user environment folder (_%appdata%/npm_) instead of node installation folder.
This should fix issues #21 and #14

Also _node.exe_ don't need absolute path because it is already "visible" at windows PATH from any location.
