### PR TITLE
Add setting to require filenames to match a regular expression on save

### DIFF
--- a/JSCS-Formatter.py
+++ b/JSCS-Formatter.py
@@ -105,6 +105,17 @@ class JscsFormatterEventListeners(sublime_plugin.EventListener):
   @staticmethod
   def on_pre_save(view):
     if PluginUtils.get_pref("format_on_save"):
+      extensions = PluginUtils.get_pref("format_on_save_extensions")
+      extension = os.path.splitext(view.file_name())[1][1:]
+
+      # Default to using filename if no extension
+      if not extension:
+        extension = os.path.basename(view.file_name())
+
+      # Skip if extension is not whitelisted
+      if extensions and not extension in extensions:
+        return
+
       view.run_command("format_javascript")
 
 class PluginUtils:

--- a/JSCS-Formatter.sublime-settings
+++ b/JSCS-Formatter.sublime-settings
@@ -20,5 +20,15 @@
   "config_path": "",
 
   // Automatically format when a file is saved.
-  "format_on_save": false
+  "format_on_save": false,
+
+  // Only attempt to format files with whitelisted extensions on save.
+  // Leave empty to disable the check
+  "format_on_save_extensions": [
+    "js",
+    "jsx",
+    "es",
+    "es6",
+    "babel"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To install via Package Control, do the following:
 
 By default, JSCSFormatter will supply the following settings:
 
-```
+```javascript
 {
   // The Nodejs installation path
   "node_path": {
@@ -60,14 +60,24 @@ By default, JSCSFormatter will supply the following settings:
     "linux": "/usr/bin/jscs",
     "osx": "/usr/local/bin/jscs"
   },
-  
+
   // Specify this path to a JSCS config file to override the default behavior.
   // Passed to JSCS as --config. Read more here:
   // http://jscs.info/overview.html#-config-
   "config_path": "",
-  
+
   // Automatically format when a file is saved.
-  "format_on_save": false
+  "format_on_save": false,
+
+  // Only attempt to format files with whitelisted extensions on save.
+  // Leave empty to disable the check
+  "format_on_save_extensions": [
+    "js",
+    "jsx",
+    "es",
+    "es6",
+    "babel"
+  ]
 }
 ```
 


### PR DESCRIPTION
Possible fix for #40
Maybe related to #26 

Currently, when the `format_on_save` setting is enabled, it attempts to format all files, even non javascript files. This can add quite a bit of lag after saving files while executing jscs. The lag is understandable when actually trying to fix javascript, but is unnecessary when saving anything else.

I've introduced a new setting called `format_on_save_extensions` which accepts a list of file extensions that saved filenames are tested against. This changes the default behavior and may be a breaking change to some people's workflow.

To opt out of the new feature, set the setting to something falsey. 

~~Old verision~~
~~I've introduced a new setting called `format_on_save_match_file_name` which accepts a regular expression that saved filenames are tested against. For backwards compatibility, I have left the default blank which disables this new feature.~~

~~To opt into the new feature, set the setting to something like `"format_on_save_match_file_name": ".*\\.jsx?"`. This will match any `.js` or `.jsx` files. Note that this will not interfere with manually executing the `format_javascript` command as I believe you should still be able to manually format non javascript files.~~
